### PR TITLE
Fixed issue with reading locked files

### DIFF
--- a/LogViewer.Server/Controllers/ViewerController.cs
+++ b/LogViewer.Server/Controllers/ViewerController.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using LogViewer.Server.Extensions;
+using LogViewer.Server.Helpers;
 using LogViewer.Server.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -45,8 +46,8 @@ namespace LogViewer.Server.Controllers
             }
 
             //Lets check file is valid JSON & not a text document on your upcoming novel
-            var firstLine = System.IO.File.ReadLines(filePath).First();
 
+            var firstLine = new FileReadHelper().ReadFileLine(filePath);
             if (firstLine.IsValidJson() == false)
             {
                 var message = $"The file {filePath} does not contain valid JSON on line one";

--- a/LogViewer.Server/Helpers/FileReadHelper.cs
+++ b/LogViewer.Server/Helpers/FileReadHelper.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Serilog.Formatting.Compact.Reader;
+
+namespace LogViewer.Server.Helpers
+{
+    public class FileReadHelper
+    {
+        /// <summary>
+        /// Reads the first line of a file
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
+        public string ReadFileLine(string filePath)
+        {
+            using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                
+                using (var stream = new StreamReader(fs))
+                {
+                    return stream.ReadLine();
+
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/warrenbuckley/Compact-Log-Format-Viewer/issues/106

Since the "main problem" was that the reading of the first line did not get access to the file.

Fixed issue with reading first line which prevent loading and reloading locked files