### PR TITLE
Fixes 313: Display error in UI from Serilog.Formatting.Compact.Reader

### DIFF
--- a/LogViewer.Server/Controllers/ViewerController.cs
+++ b/LogViewer.Server/Controllers/ViewerController.cs
@@ -65,7 +65,7 @@ namespace LogViewer.Server.Controllers
             {
                 // Can be InvalidDataExcpetion or JsonFormatterException
                 // Such as 'The data on line 1 does not include the required @t field'
-                return BadRequest($"There was a problem reading the JSON. {ex.Message}")
+                return BadRequest($"There was a problem reading the JSON. {ex.Message}");
             }
         }
 

--- a/LogViewer.Server/Controllers/ViewerController.cs
+++ b/LogViewer.Server/Controllers/ViewerController.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using LogViewer.Server.Extensions;
 using LogViewer.Server.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -57,9 +56,17 @@ namespace LogViewer.Server.Controllers
             }
 
             //We will skip over/ignore invalid/malformed log lines
-            var logs = _logParser.ReadLogs(filePath);            
-            return $"Log contains {logs.Count}";
-
+            try
+            {
+                var logs = _logParser.ReadLogs(filePath);
+                return $"Log contains {logs.Count}";
+            }
+            catch (InvalidDataException ex)
+            {
+                // Can be InvalidDataExcpetion or JsonFormatterException
+                // Such as 'The data on line 1 does not include the required @t field'
+                return BadRequest($"There was a problem reading the JSON. {ex.Message}")
+            }
         }
 
         [HttpGet("reload")]


### PR DESCRIPTION
Wraps the ReadLogs call in a try & catch the underlying library Serilog.Formatting.Compact.Reader throws InvalidDataExceptions with messages such as missing @t timestamp property

Fixes #313 to help display the error to the user

![image](https://user-images.githubusercontent.com/1389894/150133370-f45898be-7222-4a6c-be01-ec4fa3d7738d.png)
