### PR TITLE
Adds support for any file extension

### DIFF
--- a/LogViewer.Client/src/main/file.ts
+++ b/LogViewer.Client/src/main/file.ts
@@ -6,7 +6,10 @@ import * as webapi from "./webapi";
 export function openFileDialog(focusedWindow: Electron.WebContents):void {
 
     dialog.showOpenDialog({
-        filters: [{name: "Log File", extensions: ["txt", "json", "clef"]}],
+        filters: [
+            { name: "Log File", extensions: ["txt", "json", "clef"]},
+            { name: 'All Files', extensions: ['*'] }
+        ],
         properties: ["openFile"],
         title: "Open Log",
     }).then(result => {

--- a/LogViewer.Client/src/renderer/components/dropzone.ts
+++ b/LogViewer.Client/src/renderer/components/dropzone.ts
@@ -31,16 +31,6 @@ function DropZoneController($element) {
         const allFiles = ev.dataTransfer.files;
         const firstFile = allFiles[0];
 
-        // File name does not end with expected extensions
-        if (firstFile.name.endsWith(".json") === false
-            && firstFile.name.endsWith(".txt") === false
-            && firstFile.name.endsWith(".clef") === false) {
-
-            // Cancel
-            alert("File is not a .json, .txt or .clef file");
-            return;
-        }
-
         // Emit an event to 'main'
         ipcRenderer.send("logviewer.dragged-file", firstFile.path);
 

--- a/LogViewer.Server/Controllers/ViewerController.cs
+++ b/LogViewer.Server/Controllers/ViewerController.cs
@@ -32,17 +32,6 @@ namespace LogViewer.Server.Controllers
                 return NotFound(message);
             }
 
-            //Check for file extension ends with one of the following
-            //.json .txt or .clef
-
-            //Don't want to attempt to any old file type
-            var extension = Path.GetExtension(filePath);
-            if (extension != ".txt" && extension != ".json" && extension != ".clef")
-            {
-                var message = $"The file {filePath} is not a compatible log file. Can only open .json, .txt or .clef files";
-                return BadRequest(message);
-            }
-
             //Lets check file is valid JSON & not a text document on your upcoming novel
             string firstLine;
             using (var s = System.IO.File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))


### PR DESCRIPTION
Fixes #238
As mentioned in the issue a lot of people use different/custom file extensions to store these compact JSON logfiles in, these removes the checks from the UI and the Server component and relies totally on the server by opening the file and determining if the first line of the file is valid JSON.