### PR TITLE
Show message query examples

### DIFF
--- a/LogViewer.Client/src/main/appmenu.ts
+++ b/LogViewer.Client/src/main/appmenu.ts
@@ -1,4 +1,4 @@
-import { app, Menu, shell } from "electron";
+import { app, BrowserWindow, Menu, shell } from "electron";
 import * as file from "./file";
 import * as webapi from "./webapi";
 
@@ -90,6 +90,34 @@ const template: Electron.MenuItemConstructorOptions[] = [
         click() {
             shell.openExternal("https://github.com/warrenbuckley/Compact-Log-Format-Viewer");
         },
+    },
+    {
+        label: "Example Search Filters",
+        click: (menuItuem, focusedWindow) => {
+           
+            let exampleQueries = new BrowserWindow({
+                parent: focusedWindow,
+
+                center:true,                
+                modal: true,
+                show:false,
+
+                minWidth:800,
+                minHeight:600,
+
+                maximizable: false,
+                minimizable: false,
+            });
+
+            // Remove the menu that is assigned from the parent window
+            // Load the HTML page with the query examples
+            exampleQueries.removeMenu();
+            exampleQueries.loadFile("views/example-queries.html");
+
+            exampleQueries.once("ready-to-show", () => {
+                exampleQueries.show();
+            });
+        }
     }],
 }];
 

--- a/LogViewer.Client/src/main/appmenu.ts
+++ b/LogViewer.Client/src/main/appmenu.ts
@@ -117,6 +117,15 @@ const template: Electron.MenuItemConstructorOptions[] = [
             exampleQueries.once("ready-to-show", () => {
                 exampleQueries.show();
             });
+
+            // When an <a href=""> is clicked it will use the OS browser to open the link
+            // and not create a new Electron Browser Window to navigate to it
+            exampleQueries.webContents.setWindowOpenHandler( ({url}) => {
+                if (url.startsWith('https:')) {
+                    shell.openExternal(url);
+                }
+                return { action: 'deny' };
+            });
         }
     }],
 }];

--- a/LogViewer.Client/views/example-queries.html
+++ b/LogViewer.Client/views/example-queries.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html ng-app="logViewerApp">
+<head>
+    <meta charset="UTF-8">
+    <title>Compact Log Viewer: Example Queries</title>
+
+    <!-- BootStrap Dist CSS -->
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css" />
+
+    <!-- Our CSS -->
+    <link rel="stylesheet" href="../styles/app.css" type="text/css" />
+</head>
+
+<body>
+    <div class="container-fluid">
+        <h1>Help</h1>        
+
+        <h2>Common Properties</h2>
+        <p>Below is a useful guide to common properties used in <mark>Serilog.Formatting.Compact</mark></p>
+        <dl class="row">
+            <dt class="col-sm-3">@t</dt>
+            <dd class="col-sm-9">An ISO 8601 timestamp</dd>
+          
+            <dt class="col-sm-3">@l</dt>
+            <dd class="col-sm-9">An implementation-specific level identifier (string or number). Absence of property implies "informational"</dd>
+          
+            <dt class="col-sm-3">@m</dt>
+            <dd class="col-sm-9">A fully-rendered message describing the event</dd>
+
+            <dt class="col-sm-3">@mt</dt>
+            <dd class="col-sm-9">Message Template</dd>
+
+            <dt class="col-sm-3">@x</dt>
+            <dd class="col-sm-9">Exception</dd>          
+        </dl>
+
+        <hr/>
+
+        <h2>Message Queries</h2>
+        <p>Below is a useful guide to common queries used to query your logfiles</p>
+
+        <h3>StartsWith</h3>
+        <p>            
+            Find all logs where the <mark>SourceContext</mark> starts with the NameSpace <mark>Umbraco.Core</mark>
+        </p>        
+        <code>StartsWith(SourceContext, 'Umbraco.Core')</code>
+        
+        <hr/>
+
+        <h3>EndsWith</h3>
+        <p>            
+            Find all logs where the <mark>RequestPath</mark> proeprty ends with the <mark>/SomeEndpoint</mark>
+        </p>        
+        <code>EndsWith(RequestPath, '/SomeEndpoint')</code>
+        
+        <hr/>
+
+        
+
+        <h3>Has</h3>
+        <p>            
+            Find all logs that have the property <mark>Duration</mark> and the Duration is greater than 1000ms
+        </p>        
+        <code>Has(Duration) and Duration > 1000</code>
+        <code>Has(@Exception)</code>
+
+        <hr/>
+
+    </div>
+</body>
+</html>

--- a/LogViewer.Client/views/example-queries.html
+++ b/LogViewer.Client/views/example-queries.html
@@ -41,31 +41,81 @@
 
         <h3>StartsWith</h3>
         <p>            
-            Find all logs where the <mark>SourceContext</mark> starts with the NameSpace <mark>Umbraco.Core</mark>
+            Find all logs where the <mark>SourceContext</mark> starts with the NameSpace <mark>MyAwesomeProject.Core</mark>
         </p>        
-        <code>StartsWith(SourceContext, 'Umbraco.Core')</code>
-        
+        <code>StartsWith(SourceContext, 'MyAwesomeProject.Core')</code>
         <hr/>
+
 
         <h3>EndsWith</h3>
         <p>            
             Find all logs where the <mark>RequestPath</mark> proeprty ends with the <mark>/SomeEndpoint</mark>
-        </p>        
-        <code>EndsWith(RequestPath, '/SomeEndpoint')</code>
-        
+            <br/>
+            <code>EndsWith(RequestPath, '/SomeEndpoint')</code>    
+        </p>
         <hr/>
 
-        
 
         <h3>Has</h3>
         <p>            
             Find all logs that have the property <mark>Duration</mark> and the Duration is greater than 1000ms
-        </p>        
-        <code>Has(Duration) and Duration > 1000</code>
-        <code>Has(@Exception)</code>
+            <br/>
+            <code>Has(Duration) and Duration > 1000</code>
+        </p>
 
+        <p>
+            Find all logs that has an exception property (Warning, Error & Fatal with Exceptions)
+            <br/>
+            <code>Has(@Exception)</code>
+        </p>
         <hr/>
 
+
+        <h3>Not</h3>
+        <p>            
+            Find all logs where the Level is NOT <mark>Verbose</mark> and NOT <mark>Debug</mark>
+            <br/>
+            <code>Not(@Level='Verbose') and Not(@Level='Debug')</code>    
+        </p>
+        <hr/>
+
+        <h3>like</h3>
+        <p>            
+            Find all logs that the message has <mark>localhost</mark> in it with SQL like
+            <br/>
+            <code>@Message like '%localhost%'</code>    
+        </p>
+        <p>
+            Find all logs that the message that starts with <mark>hot</mark> in it with SQL like
+            <br/>
+            <code>@Message like 'hot%'</code>
+        </p>
+        <hr/>
+
+        <h3>Further examples</h3>
+        <p>
+            Below are some more examples of queries that you can use to find logs in your logfiles.
+            For a full list of supported expressions <a href="https://github.com/serilog/serilog-filters-expressions" target="_blank">see the Serilog.Filters.Expressions project</a>
+        </p>
+        <p>
+            Find all logs that use a specific log message template
+            <br/>
+            <code>@MessageTemplate = '[Timing {TimingId}] {EndMessage} ({TimingDuration}ms)'</code>
+        </p>
+
+        <p>
+            Find logs where one of the items in the SortedComponentTypes property array is equal to <mark>Umbraco.Web.Search.ExamineComponent</mark>
+            <br/>
+            <code>SortedComponentTypes[?] = 'Umbraco.Web.Search.ExamineComponent'</code>
+        </p>
+
+        <p>
+            Find logs where one of the items in the SortedComponentTypes property array contains <mark>DatabaseServer</mark>
+            <br/>
+            <code>Contains(SortedComponentTypes[?], 'DatabaseServer')</code>
+        </p>
+
+        
     </div>
 </body>
-</html>
+</html>  


### PR DESCRIPTION
Fixes #66 by adding a new application submenu item under the Help menu
This launches a new HTML page in a window to describe different example queries