### PR TITLE
When clicking error count - we match the same query we do serverside

### DIFF
--- a/LogViewer.Client/src/renderer/app-angular.ts
+++ b/LogViewer.Client/src/renderer/app-angular.ts
@@ -24,7 +24,7 @@ logViewerApp.controller("LogViewerController", ["$scope", "logViewerResource", f
 
     vm.errorCountClick = () => {
         // When we click error count - Update filter expression & do NEW search
-        vm.logOptions.filterExpression = "@Level='Error'";
+        vm.logOptions.filterExpression = "@Level='Error' or @Level='Fatal' or Has(@Exception)";
         vm.logOptions.pageNumber = 1;
         vm.performSearch();
     };


### PR DESCRIPTION
Fixes issue #459 
When clicking the error count in the log it would assume it was only an Error level.

The error count could be an Error or Fatal or it is possible for Warnings to have Exception's tied to them.
So when clicking the error count it performs the same query as it does server side to determine the number of errors.

`@Level='Error' or @Level='Fatal' or Has(@Exception)`